### PR TITLE
Add viewer command line argument

### DIFF
--- a/QuickLook/ViewWindowManager.cs
+++ b/QuickLook/ViewWindowManager.cs
@@ -220,6 +220,11 @@ internal class ViewWindowManager : IDisposable
         _viewerWindow = new ViewerWindow();
         _viewerWindow.Closed += (sender, e) =>
         {
+            if (App.ExitAfterPreview)
+            {
+                Application.Current.Shutdown();
+                return;
+            }
             if (ProcessHelper.IsShuttingDown())
                 return;
             if (sender is not ViewerWindow w || w.Pinned)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Get it from one of the following sources:
 1. Preview next file by clicking on it or using arrow-keys (arrow-keys move selection in the background if the preview window is not in focus)
 1. When you're done close it by either hitting <kbd>Spacebar</kbd> again, pressing <kbd>Esc</kbd> or clicking the `⨉` button
 
+### Command-line usage
+
+QuickLook can also be started with a file path. When launched with the `/viewer`
+option it will close automatically after the preview window is closed. This is
+useful for associating certain file types (for example `.md` Markdown files)
+with QuickLook.
+
+```powershell
+QuickLook.exe /viewer README.md
+```
+
 ### Hotkeys and buttons
 
  - <kbd>Spacebar</kbd> Show/Hide the preview window


### PR DESCRIPTION
## Summary
- add `ExitAfterPreview` to allow QuickLook to quit after closing preview
- parse `/viewer` argument and open the file supplied on command line
- exit when preview window is closed if using `/viewer`
- document command-line usage in README

## Testing
- `dotnet build QuickLook.sln -c Release` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a4e10691c83288243dae128a3f4d1